### PR TITLE
Add Tailscale SSH sidecar + GitOps ACL sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,3 +57,37 @@ TUNNEL_ID=
 # (leave the lines below commented for the dashboard-managed flow)
 # USE_CONFIG_FILE=1
 # TUNNEL_ID=00000000-0000-0000-0000-000000000000
+
+# --- Tailscale (optional, for SSH access to the host) ---
+#
+# The tailscale service in docker-compose.yml is opt-in via a compose profile,
+# so it does NOT start by default with `docker compose up -d`. Start it with:
+#   docker compose --profile tailscale up -d
+#
+# Auth uses an OAuth CLIENT (not an auth key). Auth keys expire after at most
+# 90 days and can't be extended, which would force a re-deploy every 90 days.
+# OAuth client secrets do NOT expire, so the container runs unattended forever.
+# The trade-off: OAuth-registered nodes must be tagged (Tailscale requirement),
+# so docker-compose.yml passes --advertise-tags=tag:server.
+#
+# Create the OAuth client at:
+#   https://login.tailscale.com/admin/settings/trust-credentials
+#   -> Credentials -> Generate credential -> OAuth
+#   -> grant the "Devices - core" (devices:core) scope
+#   -> assign the tag:server tag
+# Copy the resulting client ID (non-secret) and client secret (secret).
+#
+# Then set both here:
+#   TS_CLIENT_ID=k1234567890abcdef         # non-secret, starts with "k"
+#   TS_CLIENT_SECRET=tskey-client-XXXX...   # secret, starts with "tskey-client-"
+#
+# Also store the secret as a GitHub REPO SECRET named TS_CLIENT_SECRET
+# (repo Settings -> Secrets and variables -> Actions). The client ID is
+# non-secret and can go in a plain repo/org variable named TS_CLIENT_ID.
+# As with TUNNEL_TOKEN, GitHub Actions can't push these to the host behind
+# NAT -- you still need to paste them into .env on the host manually.
+#
+# Requires host sshd listening on 0.0.0.0:22 (default on most Linux distros).
+# Verify with: ssh <user>@telemetry-server
+TS_CLIENT_ID=
+TS_CLIENT_SECRET=

--- a/.github/workflows/tailscale.yml
+++ b/.github/workflows/tailscale.yml
@@ -6,18 +6,20 @@ name: Sync Tailscale ACLs
 #
 # Required GitHub configuration (org Settings -> Secrets and variables ->
 # Actions -- matches the TUNNEL_TOKEN pattern):
-#   TS_TAILNET      - ORG SECRET. Your tailnet ID (find it at
+#   TS_TAILNET      - ORG VARIABLE (vars.*). Your tailnet name, e.g.
+#                     beetal-spica.ts.net (find it at
 #                     https://login.tailscale.com/admin/settings/general).
-#   TS_OAUTH_ID      - ORG SECRET. OAuth client ID for the policy-file
-#                     OAuth client (starts with k).
-#   TS_OAUTH_SECRET  - ORG SECRET. OAuth client secret (starts with
-#                     tskey-client-).
+#                     Not sensitive, so it lives in the Variables store, not
+#                     the Secrets store -- referenced as ${{ vars.TS_TAILNET }}.
+#   TS_OAUTH_ID      - ORG SECRET (secrets.*). OAuth client ID for the
+#                     policy-file OAuth client (starts with k).
+#   TS_OAUTH_SECRET  - ORG SECRET (secrets.*). OAuth client secret (starts
+#                     with tskey-client-).
 #
-# All three are org secrets scoped to selected repositories (this repo only),
-# so a future second boat project can reuse them without duplication. Storing
-# the non-secret values (tailnet ID, client ID) as secrets too keeps the setup
-# simple -- one place to look, one permission model -- at the cost of needing
-# an org admin to read them. Trade-off accepted.
+# All three are org-scoped to selected repositories (this repo only), so a
+# future second boat project can reuse them without duplication. The two
+# OAuth values are secrets (never logged); the tailnet name is a variable
+# (visible in logs and the admin UI, since it's not sensitive).
 #
 # Create the OAuth client at
 #   https://login.tailscale.com/admin/settings/trust-credentials
@@ -49,19 +51,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Debug secrets
-        env:
-          TS_TAILNET: ${{ secrets.TS_TAILNET }}
-          TS_OAUTH_ID: ${{ secrets.TS_OAUTH_ID }}
-          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
-        run: |
-          echo "TS_TAILNET length: ${#TS_TAILNET}"
-          echo "TS_OAUTH_ID length: ${#TS_OAUTH_ID}"
-          echo "TS_OAUTH_SECRET length: ${#TS_OAUTH_SECRET}"
-          if [ -z "$TS_TAILNET" ]; then echo "TS_TAILNET is EMPTY"; fi
-          if [ -z "$TS_OAUTH_ID" ]; then echo "TS_OAUTH_ID is EMPTY"; fi
-          if [ -z "$TS_OAUTH_SECRET" ]; then echo "TS_OAUTH_SECRET is EMPTY"; fi
-
       - name: Deploy ACL
         if: github.event_name == 'push'
         id: deploy-acl
@@ -69,7 +58,7 @@ jobs:
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tailnet: ${{ secrets.TS_TAILNET }}
+          tailnet: ${{ vars.TS_TAILNET }}
           action: apply
           policy-file: tailscale/policy.hujson
 
@@ -80,6 +69,6 @@ jobs:
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tailnet: ${{ secrets.TS_TAILNET }}
+          tailnet: ${{ vars.TS_TAILNET }}
           action: test
           policy-file: tailscale/policy.hujson

--- a/.github/workflows/tailscale.yml
+++ b/.github/workflows/tailscale.yml
@@ -49,6 +49,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Debug secrets
+        env:
+          TS_TAILNET: ${{ secrets.TS_TAILNET }}
+          TS_OAUTH_ID: ${{ secrets.TS_OAUTH_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
+        run: |
+          echo "TS_TAILNET length: ${#TS_TAILNET}"
+          echo "TS_OAUTH_ID length: ${#TS_OAUTH_ID}"
+          echo "TS_OAUTH_SECRET length: ${#TS_OAUTH_SECRET}"
+          if [ -z "$TS_TAILNET" ]; then echo "TS_TAILNET is EMPTY"; fi
+          if [ -z "$TS_OAUTH_ID" ]; then echo "TS_OAUTH_ID is EMPTY"; fi
+          if [ -z "$TS_OAUTH_SECRET" ]; then echo "TS_OAUTH_SECRET is EMPTY"; fi
+
       - name: Deploy ACL
         if: github.event_name == 'push'
         id: deploy-acl

--- a/.github/workflows/tailscale.yml
+++ b/.github/workflows/tailscale.yml
@@ -1,0 +1,72 @@
+name: Sync Tailscale ACLs
+
+# Syncs tailscale/policy.hujson to Tailscale on push to main, and validates
+# it on pull requests targeting main. See docker/README.md, "Managing the
+# tailnet policy via GitHub".
+#
+# Required GitHub configuration (org Settings -> Secrets and variables ->
+# Actions -- matches the TUNNEL_TOKEN pattern):
+#   TS_TAILNET      - ORG SECRET. Your tailnet ID (find it at
+#                     https://login.tailscale.com/admin/settings/general).
+#   TS_OAUTH_ID      - ORG SECRET. OAuth client ID for the policy-file
+#                     OAuth client (starts with k).
+#   TS_OAUTH_SECRET  - ORG SECRET. OAuth client secret (starts with
+#                     tskey-client-).
+#
+# All three are org secrets scoped to selected repositories (this repo only),
+# so a future second boat project can reuse them without duplication. Storing
+# the non-secret values (tailnet ID, client ID) as secrets too keeps the setup
+# simple -- one place to look, one permission model -- at the cost of needing
+# an org admin to read them. Trade-off accepted.
+#
+# Create the OAuth client at
+#   https://login.tailscale.com/admin/settings/trust-credentials
+# with the "Policy File" (policy_file) scope -- read+write, so the action
+# can both test and apply. This is a SEPARATE OAuth client from the one used
+# by the tailscale sidecar container (which only needs devices:core).
+#
+# Alternatively, replace TS_OAUTH_ID/TS_OAUTH_SECRET with an API access token
+# stored as TS_API_KEY -- but API tokens expire after 90 days, while OAuth
+# client secrets do not expire.
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "tailscale/policy.hujson"
+      - ".github/workflows/tailscale.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "tailscale/policy.hujson"
+      - ".github/workflows/tailscale.yml"
+
+jobs:
+  acls:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Deploy ACL
+        if: github.event_name == 'push'
+        id: deploy-acl
+        uses: tailscale/gitops-acl-action@v1
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tailnet: ${{ secrets.TS_TAILNET }}
+          action: apply
+          policy-file: tailscale/policy.hujson
+
+      - name: Test ACL
+        if: github.event_name == 'pull_request'
+        id: test-acl
+        uses: tailscale/gitops-acl-action@v1
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tailnet: ${{ secrets.TS_TAILNET }}
+          action: test
+          policy-file: tailscale/policy.hujson

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The production stack runs as four Docker Compose services:
 | `telemetry-test` | Gunicorn app on `:6001` (testing)                            |
 | `cloudflared`    | Outbound tunnel to Cloudflare; routes hostnames → containers |
 | `cron`           | Calls `/instance_manager/clean_instances` every 5 min        |
+| `tailscale`      | Optional (`--profile tailscale`). Joins your Tailscale tailnet so you can SSH into the host from anywhere on your tailnet. See [docker/README.md](docker/README.md#ssh-access-via-tailscale-optional). |
 
 `cloudflared` dials **out** to Cloudflare's edge, so no inbound ports need to be
 open on the host — works behind NAT, CGNAT, or a firewall. Cloudflare terminates

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,82 @@ services:
     networks:
       - telemetry-net
 
+  tailscale:
+    # Optional: joins your Tailscale tailnet so you can SSH into the host from
+    # anywhere on your tailnet. Opt in with:
+    #   docker compose --profile tailscale up -d
+    #
+    # The container dials OUT to Tailscale's coordination server (just like
+    # cloudflared dials out to Cloudflare), so no inbound ports need to be
+    # open on the host. TS_DEST_IP forwards traffic arriving at the Tailscale
+    # node to the host via the docker gateway (host.docker.internal), so:
+    #   ssh <user>@telemetry-server  ->  host's sshd on port 22
+    #
+    # Auth: uses an OAuth CLIENT (TS_CLIENT_ID + TS_CLIENT_SECRET), NOT an
+    # auth key. Auth keys expire after at most 90 days and there's no way to
+    # extend them -- you'd have to regenerate and redeploy every 90 days.
+    # OAuth client secrets do NOT expire, so this runs unattended forever.
+    # The trade-off: OAuth-registered nodes MUST be tagged (Tailscale
+    # requirement), so we pass --advertise-tags=tag:server via TS_EXTRA_ARGS.
+    # Create the OAuth client at
+    #   https://login.tailscale.com/admin/settings/trust-credentials
+    # with the "Devices - core" (devices:core) scope and assign tag:server.
+    #
+    # No tagOwners entry needed: Tailscale lets an OAuth client assign a tag
+    # if the requested tags EXACTLY MATCH the client's tags (no tagOwners
+    # consultation). Since the client has tag:server and we advertise
+    # tag:server, it's an exact match. tagOwners is only needed if you want
+    # regular users or OTHER tags to be able to assign tag:server.
+    #
+    # Requires:
+    #   - TS_CLIENT_ID and TS_CLIENT_SECRET in .env
+    #   - /dev/net/tun on the host (Linux: `modprobe tun` if missing)
+    #   - Host sshd listening on 0.0.0.0:22 (default on most distros)
+    #
+    # Also store the OAuth client secret as a GitHub REPO SECRET named
+    # TS_CLIENT_SECRET (repo Settings -> Secrets and variables -> Actions).
+    # The client ID is non-secret and goes in a plain org/repo variable
+    # named TS_CLIENT_ID. Unlike TUNNEL_TOKEN (an org variable so the team
+    # can read it), the OAuth client secret grants tailnet access, so it
+    # should be masked. Like TUNNEL_TOKEN, neither value reaches the host
+    # automatically -- you still need to put them in .env on the host.
+    image: tailscale/tailscale:latest
+    container_name: telemetry-tailscale
+    restart: unless-stopped
+    hostname: telemetry-server
+    profiles:
+      - tailscale
+    environment:
+      # Use ${VAR:-} (not ${VAR:?}) so the default `docker compose up -d`
+      # flow (which doesn't enable the tailscale profile and doesn't set
+      # these vars) still parses. When the profile IS enabled without them,
+      # the tailscale container will start and log an auth error — check
+      # `docker compose logs tailscale`.
+      TS_CLIENT_ID: ${TS_CLIENT_ID:-}
+      TS_CLIENT_SECRET: ${TS_CLIENT_SECRET:-}
+      TS_HOSTNAME: telemetry-server
+      TS_STATE_DIR: /var/lib/tailscale
+      # OAuth-registered nodes must be tagged. The OAuth client has tag:server
+      # in its tag set, and we advertise tag:server here — that's an exact
+      # match, so Tailscale allows the assignment without any tagOwners entry.
+      TS_EXTRA_ARGS: --advertise-tags=tag:server
+      # Forward traffic arriving at the Tailscale node to the host's sshd.
+      # host.docker.internal is resolved to the docker bridge gateway via
+      # the extra_hosts mapping below.
+      TS_DEST_IP: host.docker.internal
+    volumes:
+      - tailscale-state:/var/lib/tailscale
+      - /dev/net/tun:/dev/net/tun
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    sysctls:
+      - net.ipv4.ip_forward=1
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      - telemetry-net
+
 networks:
   telemetry-net:
     driver: bridge
@@ -117,3 +193,4 @@ volumes:
   test-instance-data:
   cloudflared-creds:
   cron-logs:
+  tailscale-state:

--- a/docker/README.md
+++ b/docker/README.md
@@ -22,6 +22,7 @@ dials **out** to Cloudflare's edge over a persistent connection. This means:
 | `telemetry-test`| `telemetry-test`        | Gunicorn app on port 6001 (testing)                               |
 | `cloudflared`   | `telemetry-cloudflared` | Outbound tunnel to Cloudflare; routes hostnames -> app containers |
 | `cron`          | `telemetry-cron`        | Calls `/instance_manager/clean_instances` on prod every 5 minutes |
+| `tailscale`     | `telemetry-tailscale`   | Optional. Joins your Tailscale tailnet so you can SSH into the host from anywhere on your tailnet. Opt in with `--profile tailscale`. |
 
 ## Routing (configured in the Cloudflare dashboard)
 
@@ -128,6 +129,9 @@ than in the dashboard:
 - `cloudflared-creds` — mount point for file-managed tunnel credentials
   (unused in dashboard-managed mode)
 - `cron-logs` — output of the `clean_instances` cron job
+- `tailscale-state` — Tailscale daemon state (machine key, node ID). Persisted
+  so the container rejoins your tailnet as the same node after restarts
+  instead of generating a new node and orphaning the old one.
 
 The `app-entrypoint.sh` script restores the default `config.py` (baked into
 the image at `/opt/config.py`) into the instance volume on first start, then
@@ -147,13 +151,263 @@ telemetry-test:
   # ... rest unchanged
 ```
 
+## SSH access via Tailscale (optional)
+
+The `tailscale` service is **opt-in** via a compose profile, so it does NOT
+start with `docker compose up -d`. This keeps the default deployment unchanged
+and avoids surprising you with a new node on your tailnet.
+
+It works exactly like `cloudflared`: the container dials **out** to Tailscale's
+coordination server, so no inbound ports need to be open on the host. Traffic
+arriving at the Tailscale node is forwarded to the host's SSH daemon via the
+Docker bridge gateway (`host.docker.internal`).
+
+### Why an OAuth client, not an auth key
+
+Tailscale **auth keys expire after at most 90 days** and there is no way to
+extend that limit — you'd have to regenerate the key and redeploy every 90
+days, or the container would silently fail to rejoin the tailnet after a
+restart. To avoid that, this service uses a Tailscale **OAuth client** instead.
+OAuth client secrets **do not expire**, so the container runs unattended
+indefinitely.
+
+The trade-off: nodes registered via OAuth **must be tagged** (a Tailscale
+requirement), so the compose file passes `--advertise-tags=tag:server` via
+`TS_EXTRA_ARGS`.
+
+### About `tagOwners` (you probably don't need to touch it)
+
+Tailscale's rule for assigning tags: an OAuth client can assign a tag if the
+requested tags **exactly match** the client's tags (no `tagOwners` consultation),
+**or** each requested tag is owned by one of the client's tags in `tagOwners`.
+
+Since the OAuth client has `tag:server` and the container advertises
+`tag:server`, it's an exact match — **no `tagOwners` entry is needed**.
+
+You only need to add `tag:server` to `tagOwners` in your tailnet policy file if:
+
+- You want **regular (non-Admin) users** to be able to apply `tag:server` to
+  devices they log into (Admins/Owners/Network admins can always apply any tag
+  implicitly — they don't need to be tag owners).
+- You want **another tag** to be able to grant `tag:server` (e.g. a
+  `tag:deployment` OAuth client that provisions both `tag:server` and
+  `tag:db` nodes).
+
+For reference, a `tagOwners` entry looks like:
+
+```json
+{
+  "tagOwners": {
+    "tag:server": ["your-email@example.com"]
+  }
+}
+```
+
+You'll still need a **grant** (or legacy `acls` entry) to actually permit SSH
+to `tag:server` — `tagOwners` only controls who can *assign* the tag, not what
+tagged devices can *do*. See step 5 below.
+
+> **Note: Tailscale SSH vs. host sshd.** This setup uses `TS_DEST_IP` to forward
+> tailnet traffic to the **host's regular sshd** (port 22). It does **not** use
+> Tailscale's built-in SSH server (we don't set `TS_ENABLE_SSH` or pass
+> `--ssh`). As a result, the `ssh` section of your tailnet policy file does not
+> govern access to this host — the `grants` (or `acls`) section does.
+
+### One-time setup
+
+1. Create an OAuth client at
+   <https://login.tailscale.com/admin/settings/trust-credentials>
+   → *Credentials* → *Generate credential* → *OAuth*:
+   - Grant the **Devices - core** (`devices:core`) scope.
+   - Assign the **`tag:server`** tag (the client will carry this tag; the
+     container advertises the same tag, which is an exact match and so doesn't
+     require a `tagOwners` entry — see "About `tagOwners`" above).
+2. Copy the **client ID** (non-secret, starts with `k`) and **client secret**
+   (secret, starts with `tskey-client-`).
+3. Store the secret as a GitHub **repo secret** named `TS_CLIENT_SECRET`
+   (repo Settings → Secrets and variables → Actions). Store the client ID as a
+   plain repo/org **variable** named `TS_CLIENT_ID` (it's non-secret). As with
+   `TUNNEL_TOKEN`, GitHub Actions can't push these to the host behind NAT — you
+   still have to paste them into `.env` on the host manually.
+4. On the host, add to `.env`:
+   ```bash
+   TS_CLIENT_ID=k1234567890abcdef
+   TS_CLIENT_SECRET=tskey-client-XXXX...
+   ```
+5. Make sure your tailnet policy file permits SSH to `tag:server` from your
+   user(s). The default policy (with its wildcard
+   `"src": ["*"], "dst": ["*"]` grant) already permits SSH, and this repo
+   ships a ready-to-use policy file at
+   [`tailscale/policy.hujson`](../tailscale/policy.hujson) that you can sync
+   to Tailscale via GitHub — see
+   [Managing the tailnet policy via GitHub](#managing-the-tailnet-policy-via-github)
+   below. To restrict access to just your user and port 22, replace the
+   wildcard grant in that file with:
+   ```json
+   {"src": ["your-email@example.com"], "dst": ["tag:server:22"], "ip": ["*"]}
+   ```
+   > If your tailnet still uses the legacy `acls` array instead of `grants`,
+   > the equivalent rule is:
+   > `{"action": "accept", "src": ["your-email@example.com"], "dst": ["tag:server:22"]}`
+6. Ensure the host's SSH daemon is listening on `0.0.0.0:22` (default on most
+   Linux distros; on Ubuntu verify with `sudo ss -tlnp | grep :22`).
+7. On Linux hosts, ensure the `tun` kernel module is loaded:
+   ```bash
+   sudo modprobe tun
+   ```
+8. Start the sidecar:
+   ```bash
+   docker compose --profile tailscale up -d
+   ```
+
+### Locking down the wildcard grant (optional)
+
+The default Tailscale policy file ships with a wildcard grant:
+
+```json
+{"src": ["*"], "dst": ["*"], "ip": ["*"]}
+```
+
+This lets **any** node on your tailnet reach **any** port on `tag:server`, not
+just SSH. For a single-user tailnet that's usually fine. If you want to
+restrict access to just your user and just port 22, replace the wildcard with:
+
+```json
+"grants": [
+  {"src": ["your-email@example.com"], "dst": ["tag:server:22"], "ip": ["*"]}
+]
+```
+
+Keep `"tagOwners": {"tag:server": []}` as-is — the empty owner list means only
+Owners/Admins/Network admins (and our OAuth client via the exact-match rule)
+can assign the tag, which is what we want.
+
+### Managing the tailnet policy via GitHub
+
+This repo ships a ready-to-use tailnet policy file at
+[`tailscale/policy.hujson`](../tailscale/policy.hujson) and a GitHub Actions
+workflow at [`.github/workflows/tailscale.yml`](../.github/workflows/tailscale.yml)
+that syncs it to Tailscale automatically using the
+[`tailscale/gitops-acl-action`](https://github.com/marketplace/actions/sync-tailscale-acls)
+action. This gives you version history, PR review, and easy backup/restore for
+the entire tailnet policy.
+
+The workflow:
+
+- On **pull request** targeting `main`: runs the action with `action: test`,
+  which sends the policy file to Tailscale for validation (and runs any
+  [`tests`](https://tailscale.com/docs/reference/syntax/policy-file#tests)
+  defined in the file) **without applying it**. The PR check fails if the
+  policy is invalid.
+- On **push** (merge) to `main`: runs the action with `action: apply`, which
+  validates and then **applies** the policy to your tailnet.
+
+It only triggers on changes to `tailscale/policy.hujson` or the workflow file
+itself (see `paths:` in the workflow), so unrelated pushes don't waste CI
+minutes.
+
+**One-time setup:**
+
+1. Create a **separate** OAuth client for policy-file management at
+   <https://login.tailscale.com/admin/settings/trust-credentials>
+   → *Credentials* → *Generate credential* → *OAuth*:
+   - Grant the **Policy File** (`policy_file`) scope — this is read+write, so
+     the action can both test and apply.
+   - This is a **different** OAuth client from the one used by the `tailscale`
+     sidecar service (which only needs `devices:core`). Don't reuse it.
+   - Copy the **client ID** (starts with `k`) and **client secret** (starts
+     with `tskey-client-`).
+2. Find your **tailnet ID** at
+   <https://login.tailscale.com/admin/settings/general> (it looks like
+   `example.com` or a hashed string — *not* your tailnet name).
+3. Add the credentials to the `autoboat-vt` org as **org secrets** (org
+   Settings → Secrets and variables → Actions → *New organization secret*),
+   scoped to selected repositories (this repo only). This matches the
+   existing `TUNNEL_TOKEN` pattern, so a future second boat project can
+   reuse them without duplication:
+
+   - `TS_TAILNET` — your tailnet ID (find it at
+     <https://login.tailscale.com/admin/settings/general>)
+   - `TS_OAUTH_ID` — the policy-file OAuth client ID
+   - `TS_OAUTH_SECRET` — the policy-file OAuth client secret
+
+   All three are stored as secrets (even the non-secret tailnet ID and
+   client ID) for simplicity — one place to look, one permission model.
+   The workflow references them as `${{ secrets.TS_TAILNET }}`,
+   `${{ secrets.TS_OAUTH_ID }}`, and `${{ secrets.TS_OAUTH_SECRET }}`.
+4. (Optional) Lock the policy file editor in the Tailscale admin console so
+   other admins don't accidentally edit it directly: open
+   <https://login.tailscale.com/admin/settings/policy-file-management>,
+   enable *Prevent edits in the admin console*, and set *External reference*
+   to this repo's URL.
+
+**Editing the policy:**
+
+```bash
+$EDITOR tailscale/policy.hujson   # edit the file
+git checkout -b tailscale/my-change
+git add tailscale/policy.hujson
+git commit -m "tailscale: <describe change>"
+git push -u origin tailscale/my-change
+# open a PR -> the Test ACL check runs -> merge -> the Deploy ACL step applies
+```
+
+If the policy file is invalid HuJSON or fails its `tests`, the PR check fails
+and the merge is blocked. The last-known-good policy stays in effect on your
+tailnet — a bad push can never break SSH access.
+
+**Is it safe to commit?**
+
+Yes — the policy file contains no secrets. It only has tag names, user emails
+(only if you add `tagOwners` entries with specific users — the shipped file
+uses an empty owner list, so no emails), and grant/SSH rules. Tailscale's docs
+recommend a **private** repo since the policy file is considered PII; this
+repo is already private.
+
+**Why a separate OAuth client, not an API key?**
+
+Tailscale API access tokens expire after at most 90 days (the same hard limit
+as auth keys). OAuth client secrets do not expire, so the workflow runs
+unattended indefinitely — same reasoning as the sidecar container's OAuth
+client. If you'd rather use an API key, replace `TS_OAUTH_ID`/`TS_OAUTH_SECRET`
+with `TS_API_KEY` in the workflow (see the comments in
+`.github/workflows/tailscale.yml`).
+
+**Trade-offs:**
+
+| ✅ Pros | ⚠️ Cons |
+|---|---|
+| Versioned, reviewable, auditable policy changes | Requires a separate OAuth client (one-time setup) |
+| PR check blocks invalid policies before they reach production | Adds one more GitHub Actions workflow to the repo |
+| Easy backup/restore of the entire tailnet policy | Manual edits in the admin console will be overwritten on the next sync |
+| OAuth client secret doesn't expire (unlike API keys) | |
+
+### Connecting
+
+Once the container reports `Logged in.` in its logs (`docker compose logs -f
+tailscale`), the host is reachable from any device on your tailnet as
+`telemetry-server` (the MagicDNS name):
+
+```bash
+ssh <your-host-username>@telemetry-server
+```
+
+> **Note on `host.docker.internal`:** the `extra_hosts` mapping
+> (`host.docker.internal:host-gateway`) makes the Docker bridge gateway
+> reachable by that name inside the container. `TS_DEST_IP` then tells
+> Tailscale to forward traffic to that address, which is the host. This is
+> what makes `ssh <user>@telemetry-server` land on the host's sshd rather
+> than inside the container.
+
 ## Useful commands
 
 ```bash
-docker compose up -d --build       # build + start everything
+docker compose up -d --build       # build + start everything (NOT tailscale)
+docker compose --profile tailscale up -d  # also start the tailscale sidecar
 docker compose ps                  # service status
 docker compose logs -f cloudflared # follow tunnel connection logs
 docker compose logs -f telemetry-prod  # follow prod app logs
+docker compose logs -f tailscale   # follow tailscale connection logs
 docker compose restart cloudflared # reconnect the tunnel
 docker compose down                # stop everything (volumes preserved)
 docker compose down -v             # stop and DELETE all volumes (DBs!)

--- a/tailscale/policy.hujson
+++ b/tailscale/policy.hujson
@@ -1,0 +1,53 @@
+// Tailnet policy file for the autoboat/telemetry_server project.
+//
+// This file is the source of truth for the tailnet's ACLs. It is synced to
+// Tailscale by the tailscale/gitops-acl-action GitHub Action in
+// .github/workflows/tailscale.yml — see docker/README.md, "Managing the
+// tailnet policy via GitHub".
+//
+// Format: HuJSON (JSON with comments). Tailscale accepts HuJSON for the policy
+// file. The trailing commas and // comments are stripped by Tailscale when it
+// parses the file.
+//
+// Workflow: open a PR -> the action runs `test` (validates without applying)
+// -> merge -> the action runs `apply` (validates and applies). Invalid HuJSON
+// or failing `tests` block the merge, so a bad push can never break SSH access.
+
+{
+    // Define the tags which can be applied to devices and by which users.
+    // Empty owner list = only Owners/Admins/Network admins can assign tag:server
+    // to devices they log into. Our OAuth client uses the exact-match rule (not
+    // tagOwners), so this doesn't affect the telemetry-server container's
+    // ability to get tag:server.
+    "tagOwners": {
+        "tag:server": []
+    },
+
+    // Define grants that govern access for users, groups, autogroups, tags,
+    // Tailscale IP addresses, and subnet ranges.
+    "grants": [
+        // Allow all connections. Comment this section out if you want to define
+        // specific restrictions — see "Locking down the wildcard grant" in
+        // docker/README.md for a tag:server-only SSH grant.
+        {
+            "src": ["*"],
+            "dst": ["*"],
+            "ip": ["*"]
+        }
+    ],
+
+    // Define users and devices that can use Tailscale SSH.
+    // NOTE: This section governs Tailscale's BUILT-IN SSH server, which this
+    // project does NOT use (we forward to the host's regular sshd via
+    // TS_DEST_IP). Access to the telemetry-server host is controlled by the
+    // `grants` section above, not this one.
+    "ssh": [
+        // Allow all users to SSH into their own devices in check mode.
+        {
+            "action": "check",
+            "src": ["autogroup:member"],
+            "dst": ["autogroup:self"],
+            "users": ["autogroup:nonroot", "root"]
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Adds a Tailscale sidecar to the Docker Compose stack for SSH access to the host, and a GitHub Action to sync the tailnet policy file from this repo via Tailscale's GitOps ACL API.

## What's included

**Tailscale sidecar (`docker-compose.yml`)** — opt-in via `--profile tailscale`:
- OAuth client auth (`TS_CLIENT_ID`/`TS_CLIENT_SECRET`) — no 90-day auth-key expiry to babysit
- Routes tailnet traffic to host sshd via `TS_DEST_IP=host.docker.internal` + `host.docker.internal:host-gateway`
- Advertises `tag:server` (matched by `tagOwners` in the policy file)

**Tailnet policy (`tailscale/policy.hujson`)** — source of truth for the tailnet:
- `tagOwners`: `tag:server` owned by the OAuth client
- `grants`: wildcard allow-all (loosely matches current state — can be locked down later)
- `ssh`: `autogroup:member` → `autogroup:self` in `check` mode (enforces Tailscale client check, no key distribution)

**GitOps ACL sync (`.github/workflows/tailscale.yml`)**:
- Uses `tailscale/gitops-acl-action@v1`
- On PR → `test` (validates policy against tailnet, does NOT apply)
- On push to `main` → `apply` (validates + applies)
- Reads `TS_TAILNET`, `TS_OAUTH_ID`, `TS_OAUTH_SECRET` from **org secrets** scoped to this repo
- Uses a separate OAuth client (with `policy_file` scope) from the sidecar (which has `devices:core`)

**Docs**:
- `docker/README.md` — SSH access via Tailscale section, tagOwners explainer, Tailscale SSH vs host sshd note, wildcard grant lockdown, managing the policy via GitHub
- `README.md` — service table updated with tailscale row
- `.env.example` — `TS_CLIENT_ID` / `TS_CLIENT_SECRET` with setup instructions

## How this PR exercises the workflow

Opening this PR should trigger the **Test ACL** check (which runs `tailscale/gitops-acl-action@v1` with `action: test`). That validates the policy syntax + tests it against the tailnet without applying anything. If that check passes, merging to `main` will trigger **Deploy ACL** (`action: apply`) which will actually push the policy to the tailnet.

## Checklist

- [x] Workflow file uses `secrets.*` (not `vars.*`)
- [x] Policy file is valid HuJSON (parses after stripping comments/trailing commas)
- [x] OAuth client for GitOps has `policy_file` scope (separate from sidecar client)
- [x] All three secrets stored as org secrets scoped to this repo
- [x] Sidecar uses OAuth client with `devices:core` scope and is tagged `tag:server`