### PR TITLE
Bake Tailscale OAuth creds into custom image (zero-touch provisioning)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,21 +73,22 @@ TUNNEL_ID=
 # Create the OAuth client at:
 #   https://login.tailscale.com/admin/settings/trust-credentials
 #   -> Credentials -> Generate credential -> OAuth
-#   -> grant the "Devices - core" (devices:core) scope
+#   -> grant BOTH "Devices - core" (devices:core) AND "Policy File"
+#      (policy_file) scopes (same client is reused by the GitOps ACL workflow)
 #   -> assign the tag:server tag
-# Copy the resulting client ID (non-secret) and client secret (secret).
 #
-# Then set both here:
-#   TS_CLIENT_ID=k1234567890abcdef         # non-secret, starts with "k"
-#   TS_CLIENT_SECRET=tskey-client-XXXX...   # secret, starts with "tskey-client-"
+# The credentials are BAKED INTO the custom tailscale image at build time
+# (see docker/tailscale/Dockerfile and .github/workflows/build.yml). They are
+# NOT read from .env on the host. Store them as GitHub ORG secrets/variables:
+#   TS_OAUTH_ID      - ORG VARIABLE (vars.*). Client ID (non-secret, starts with k).
+#   TS_OAUTH_SECRET  - ORG SECRET (secrets.*). Client secret (starts with tskey-client-).
+# Both scoped to this repo only. The build workflow reads them and passes as
+# build-args to docker/tailscale/Dockerfile.
 #
-# Also store the secret as a GitHub REPO SECRET named TS_CLIENT_SECRET
-# (repo Settings -> Secrets and variables -> Actions). The client ID is
-# non-secret and can go in a plain repo/org variable named TS_CLIENT_ID.
-# As with TUNNEL_TOKEN, GitHub Actions can't push these to the host behind
-# NAT -- you still need to paste them into .env on the host manually.
+# SECURITY: the custom tailscale image is PRIVATE on GHCR (it contains the
+# OAuth client secret). Before `docker compose pull` works on a host, you need
+# a one-time `docker login ghcr.io` with a PAT that has `read:packages` scope.
+# Create the PAT at https://github.com/settings/tokens (classic).
 #
 # Requires host sshd listening on 0.0.0.0:22 (default on most Linux distros).
 # Verify with: ssh <user>@telemetry-server
-TS_CLIENT_ID=
-TS_CLIENT_SECRET=

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,3 +76,51 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha,scope=${{ matrix.architecture }}
           cache-to: type=gha,mode=max,scope=${{ matrix.architecture }}
+
+      # ---------------------------------------------------------------------
+      # Custom tailscale image with OAuth creds baked in (no host-side .env).
+      # Built ONLY on push (not PR) because PR runs from forks don't have
+      # access to org secrets. The image is multi-arch alongside the main
+      # image. SECURITY: this image must be private on GHCR -- see
+      # docker/tailscale/Dockerfile.
+      #
+      # Uses the SAME OAuth client as the GitOps ACL workflow (one client with
+      # both `devices:core` and `policy_file` scopes). TS_OAUTH_ID is stored as
+      # an org VARIABLE (non-secret, readable by Actions and by this build
+      # step via vars.*). TS_OAUTH_SECRET is an org SECRET (write-only from
+      # Actions, but readable here because build-push-action passes it as a
+      # build-arg without echoing it).
+      # ---------------------------------------------------------------------
+      - name: Compute tailscale image tags
+        if: github.event_name == 'push'
+        id: meta-tailscale
+        run: |
+          OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}
+          GHCR_REPO="ghcr.io/${OWNER_LC}/telemetry_server-tailscale"
+
+          tags="$(SOURCE_REF_NAME=${GITHUB_REF_NAME} sh .github/scripts/compute-release-tags.sh base)"
+
+          refs=""
+          for t in $tags; do
+            refs="${refs}${GHCR_REPO}:${t}-${{ matrix.architecture }}\n"
+          done
+          {
+            echo "tags<<EOF"
+            printf "%b" "$refs"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Build tailscale image
+        if: github.event_name == 'push'
+        uses: docker/build-push-action@v6
+        with:
+          context: ./docker/tailscale
+          file: ./docker/tailscale/Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ${{ steps.meta-tailscale.outputs.tags }}
+          build-args: |
+            TS_CLIENT_ID=${{ vars.TS_OAUTH_ID }}
+            TS_CLIENT_SECRET=${{ secrets.TS_OAUTH_SECRET }}
+          cache-from: type=gha,scope=tailscale-${{ matrix.architecture }}
+          cache-to: type=gha,mode=max,scope=tailscale-${{ matrix.architecture }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -72,3 +72,18 @@ jobs:
             docker buildx imagetools create -t ${DOCKER_HUB_REPO}:${tag} \
               ${GHCR_REPO}:${tag}
           done
+
+          # -----------------------------------------------------------------
+          # Custom tailscale image (with OAuth creds baked in). GHCR only --
+          # NOT mirrored to Docker Hub, because the image is PRIVATE (it
+          # contains a secret) and Docker Hub doesn't get the private
+          # treatment. Hosts must `docker login ghcr.io` to pull this.
+          # -----------------------------------------------------------------
+          TS_GHCR_REPO="ghcr.io/${OWNER_LC}/telemetry_server-tailscale"
+
+          for tag in $tags; do
+            echo "==> Assembling multi-arch manifest on GHCR: ${TS_GHCR_REPO}:${tag}"
+            docker buildx imagetools create -t ${TS_GHCR_REPO}:${tag} \
+              ${TS_GHCR_REPO}:${tag}-amd64 \
+              ${TS_GHCR_REPO}:${tag}-arm64
+          done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,7 +127,10 @@ services:
     # requirement), so we pass --advertise-tags=tag:server via TS_EXTRA_ARGS.
     # Create the OAuth client at
     #   https://login.tailscale.com/admin/settings/trust-credentials
-    # with the "Devices - core" (devices:core) scope and assign tag:server.
+    # with BOTH the "Devices - core" (devices:core) AND "Policy File"
+    # (policy_file) scopes, and assign the tag:server tag. The same OAuth
+    # client is reused by the GitOps ACL workflow in
+    # .github/workflows/tailscale.yml.
     #
     # No tagOwners entry needed: Tailscale lets an OAuth client assign a tag
     # if the requested tags EXACTLY MATCH the client's tags (no tagOwners
@@ -136,31 +139,28 @@ services:
     # regular users or OTHER tags to be able to assign tag:server.
     #
     # Requires:
-    #   - TS_CLIENT_ID and TS_CLIENT_SECRET in .env
     #   - /dev/net/tun on the host (Linux: `modprobe tun` if missing)
     #   - Host sshd listening on 0.0.0.0:22 (default on most distros)
     #
-    # Also store the OAuth client secret as a GitHub REPO SECRET named
-    # TS_CLIENT_SECRET (repo Settings -> Secrets and variables -> Actions).
-    # The client ID is non-secret and goes in a plain org/repo variable
-    # named TS_CLIENT_ID. Unlike TUNNEL_TOKEN (an org variable so the team
-    # can read it), the OAuth client secret grants tailnet access, so it
-    # should be masked. Like TUNNEL_TOKEN, neither value reaches the host
-    # automatically -- you still need to put them in .env on the host.
-    image: tailscale/tailscale:latest
+    # The OAuth credentials are BAKED INTO the custom image (built in
+    # .github/workflows/build.yml from docker/tailscale/Dockerfile). The
+    # upstream tailscale/tailscale image is extended with ENV vars set from
+    # build args passed by GitHub Actions (where the org secrets are
+    # available). This means NO .env paste is required on the host -- the
+    # image is self-contained.
+    #
+    # SECURITY: this image is PRIVATE on GHCR (it contains the OAuth client
+    # secret). Hosts must `docker login ghcr.io` before `docker compose pull`.
+    # See docker/README.md and docker/tailscale/Dockerfile for details.
+    image: ghcr.io/autoboat-vt/telemetry_server-tailscale:latest
     container_name: telemetry-tailscale
     restart: unless-stopped
     hostname: telemetry-server
     profiles:
       - tailscale
     environment:
-      # Use ${VAR:-} (not ${VAR:?}) so the default `docker compose up -d`
-      # flow (which doesn't enable the tailscale profile and doesn't set
-      # these vars) still parses. When the profile IS enabled without them,
-      # the tailscale container will start and log an auth error — check
-      # `docker compose logs tailscale`.
-      TS_CLIENT_ID: ${TS_CLIENT_ID:-}
-      TS_CLIENT_SECRET: ${TS_CLIENT_SECRET:-}
+      # TS_CLIENT_ID and TS_CLIENT_SECRET come from the image (baked in at
+      # build time via docker/tailscale/Dockerfile). No host-side .env needed.
       TS_HOSTNAME: telemetry-server
       TS_STATE_DIR: /var/lib/tailscale
       # OAuth-registered nodes must be tagged. The OAuth client has tag:server

--- a/docker/README.md
+++ b/docker/README.md
@@ -218,23 +218,21 @@ tagged devices can *do*. See step 5 below.
 1. Create an OAuth client at
    <https://login.tailscale.com/admin/settings/trust-credentials>
    → *Credentials* → *Generate credential* → *OAuth*:
-   - Grant the **Devices - core** (`devices:core`) scope.
+   - Grant **BOTH** the **Devices - core** (`devices:core`) AND **Policy File**
+     (`policy_file`) scopes. (The same client is reused by the GitOps ACL
+     workflow in `.github/workflows/tailscale.yml` — no need for a second one.)
    - Assign the **`tag:server`** tag (the client will carry this tag; the
      container advertises the same tag, which is an exact match and so doesn't
      require a `tagOwners` entry — see "About `tagOwners`" above).
 2. Copy the **client ID** (non-secret, starts with `k`) and **client secret**
    (secret, starts with `tskey-client-`).
-3. Store the secret as a GitHub **repo secret** named `TS_CLIENT_SECRET`
-   (repo Settings → Secrets and variables → Actions). Store the client ID as a
-   plain repo/org **variable** named `TS_CLIENT_ID` (it's non-secret). As with
-   `TUNNEL_TOKEN`, GitHub Actions can't push these to the host behind NAT — you
-   still have to paste them into `.env` on the host manually.
-4. On the host, add to `.env`:
-   ```bash
-   TS_CLIENT_ID=k1234567890abcdef
-   TS_CLIENT_SECRET=tskey-client-XXXX...
-   ```
-5. Make sure your tailnet policy file permits SSH to `tag:server` from your
+3. Store them as GitHub **org** secrets/variables (org Settings → Secrets and
+   variables → Actions), scoped to this repo only:
+   - `TS_OAUTH_ID` — org **variable** (`vars.*`). Client ID. Non-secret, so a
+     variable lets the build workflow read it via `${{ vars.TS_OAUTH_ID }}`.
+   - `TS_OAUTH_SECRET` — org **secret** (`secrets.*`). Client secret. Read by
+     both the GitOps ACL workflow and the image build workflow.
+4. Make sure your tailnet policy file permits SSH to `tag:server` from your
    user(s). The default policy (with its wildcard
    `"src": ["*"], "dst": ["*"]` grant) already permits SSH, and this repo
    ships a ready-to-use policy file at
@@ -249,12 +247,20 @@ tagged devices can *do*. See step 5 below.
    > If your tailnet still uses the legacy `acls` array instead of `grants`,
    > the equivalent rule is:
    > `{"action": "accept", "src": ["your-email@example.com"], "dst": ["tag:server:22"]}`
-6. Ensure the host's SSH daemon is listening on `0.0.0.0:22` (default on most
+5. Ensure the host's SSH daemon is listening on `0.0.0.0:22` (default on most
    Linux distros; on Ubuntu verify with `sudo ss -tlnp | grep :22`).
-7. On Linux hosts, ensure the `tun` kernel module is loaded:
+6. On Linux hosts, ensure the `tun` kernel module is loaded:
    ```bash
    sudo modprobe tun
    ```
+7. **One-time `docker login` on the host** — the custom tailscale image is
+   **private** on GHCR (it has the OAuth client secret baked in, see
+   [`docker/tailscale/Dockerfile`](tailscale/Dockerfile)). Create a classic PAT
+   at <https://github.com/settings/tokens> with `read:packages` scope, then:
+   ```bash
+   echo "<PAT>" | docker login ghcr.io -u <github-username> --password-stdin
+   ```
+   This caches creds in `~/.docker/config.json` — do it once per host.
 8. Start the sidecar:
    ```bash
    docker compose --profile tailscale up -d

--- a/docker/tailscale/Dockerfile
+++ b/docker/tailscale/Dockerfile
@@ -1,0 +1,39 @@
+# Custom tailscale image with OAuth credentials baked in.
+#
+# WHY: the upstream `tailscale/tailscale:latest` image reads TS_CLIENT_ID and
+# TS_CLIENT_SECRET from environment variables at runtime. That requires the
+# host to provide them via .env, which means a manual paste on every new host.
+#
+# This image bakes the credentials in as ENV at build time, so the image is
+# self-contained: `docker compose --profile tailscale up -d` works with zero
+# host-side configuration. The build happens in GitHub Actions, where the
+# secrets ARE available (as org secrets/vars), so they never touch a developer
+# machine or the repo's git history.
+#
+# SECURITY: this image MUST be private on GHCR. The baked-in OAuth client
+# secret grants tailnet access (register devices as tag:server, SSH to
+# tag:server hosts, and -- because we use one client with both scopes --
+# read/write the tailnet policy). Anyone who can `docker pull` this image can
+# extract the secret. Make the GHCR package private at:
+#   https://github.com/orgs/autoboat-vt/packages/container/telemetry_server-tailscale/settings
+# And require `docker login ghcr.io` on the host before `docker compose pull`.
+#
+# Uses the SAME OAuth client as the GitOps ACL workflow (one client with both
+# `devices:core` and `policy_file` scopes). Build args are passed from the
+# build workflow:
+#   TS_CLIENT_ID      - non-secret, starts with k. Read from org variable
+#                       TS_OAUTH_ID (renamed here to match containerboot's
+#                       expected env var name).
+#   TS_CLIENT_SECRET  - secret, starts with tskey-client-. Read from org
+#                       secret TS_OAUTH_SECRET.
+
+FROM tailscale/tailscale:latest
+
+ARG TS_CLIENT_ID
+ARG TS_CLIENT_SECRET
+
+# Persist as runtime env vars. containerboot reads these on startup.
+# These are baked into the image layers -- hence the "image MUST be private"
+# warning above.
+ENV TS_CLIENT_ID=${TS_CLIENT_ID}
+ENV TS_CLIENT_SECRET=${TS_CLIENT_SECRET}


### PR DESCRIPTION
## Summary

Replaces the upstream `tailscale/tailscale:latest` image with a custom `ghcr.io/autoboat-vt/telemetry_server-tailscale:latest` image that has the OAuth credentials **baked in at build time**. This eliminates the manual `.env` paste on every new host — the image is self-contained, so `docker compose --profile tailscale up -d` works with zero host-side credential configuration.

## What changes

- **`docker/tailscale/Dockerfile`** (new): `FROM tailscale/tailscale:latest`, takes `TS_CLIENT_ID` and `TS_CLIENT_SECRET` as build args, persists them as `ENV` so containerboot reads them at runtime.
- **`.github/workflows/build.yml`**: also builds the tailscale image (on push only, not PR — org secrets aren't available on fork PRs). Passes `TS_OAUTH_ID` (org variable) and `TS_OAUTH_SECRET` (org secret) as build-args.
- **`.github/workflows/push.yml`**: assembles the multi-arch manifest for the tailscale image on GHCR only (NOT mirrored to Docker Hub, since the image is private).
- **`docker-compose.yml`**: uses the custom image, drops the `${TS_CLIENT_ID:-}` / `${TS_CLIENT_SECRET:-}` env var substitution.
- **`.env.example`** + **`docker/README.md`**: updated docs to describe the new flow.

## Security model

⚠️ **The custom image MUST be private on GHCR.** It contains the OAuth client secret, which grants tailnet access (register devices as `tag:server`, SSH to `tag:server` hosts, read/write tailnet policy). Anyone who can `docker pull` the image can extract the secret.

After merge, make the package private at:
https://github.com/orgs/autoboat-vt/packages/container/telemetry_server-tailscale/settings

Hosts need a one-time `docker login ghcr.io` with a PAT (`read:packages` scope) before `docker compose pull` works.

## OAuth client

Uses the **same** OAuth client as the GitOps ACL workflow (one client with both `devices:core` and `policy_file` scopes). No need to create a second one.

## Required org secrets/variables (already in place)

- `TS_OAUTH_ID` — org **variable** (client ID, non-secret, readable by the build via `vars.*`)
- `TS_OAUTH_SECRET` — org **secret** (client secret)
- `TS_TAILNET` — org **variable** (tailnet name, used by the GitOps workflow)

## After merge

1. Make the `telemetry_server-tailscale` GHCR package private (link above)
2. Wait for the build/publish workflows to run (they'll trigger on the merge push)
3. Verify the image appears at https://github.com/orgs/autoboat-vt/packages/container/telemetry_server-tailscale
4. On the host: one-time `docker login ghcr.io`, then `docker compose --profile tailscale up -d`

## Checklist

- [x] Custom Dockerfile bakes creds as ENV (containerboot reads them at runtime)
- [x] Build workflow passes org var/secret as build-args
- [x] Publish workflow assembles multi-arch manifest on GHCR only
- [x] docker-compose.yml uses custom image, no host-side env vars
- [x] Docs updated (.env.example, docker/README.md)
- [x] Workflows validate as YAML
- [ ] GHCR package made private after merge
- [ ] Build/publish workflows run green