### PR TITLE
Add CORS support for website frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,19 @@ DOMAIN=vt-autoboat-telemetry.uk
 # use a hostname instead since tunnels route by hostname, not port.
 TESTING_DOMAIN=test.vt-autoboat-telemetry.uk
 
+# Comma-separated list of origins allowed to make cross-origin requests to
+# the telemetry API (sent as Access-Control-Allow-Origin). The Autoboat
+# website (https://autoboat.aoe.vt.edu) fetches boat positions from this API
+# in the browser, so its origin must be listed here.
+#
+# Leave blank to use the built-in default (the website origin, the prod/test
+# telemetry origins, and localhost:5173 for local dev — see
+# DEFAULT_CORS_ORIGINS in src/autoboat_telemetry_server/__init__.py).
+# Set this to override the default, e.g. to add a preview/staging deploy of
+# the website:
+#   CORS_ORIGINS=https://autoboat.aoe.vt.edu,https://vt-autoboat-telemetry.uk,https://www.vt-autoboat-telemetry.uk,https://test.vt-autoboat-telemetry.uk,http://localhost:5173
+CORS_ORIGINS=
+
 # --- Dashboard-managed tunnel (recommended) ---
 #
 # 1. Go to https://one.dash.cloudflare.com/ -> Networks -> Tunnels -> Create
@@ -57,38 +70,3 @@ TUNNEL_ID=
 # (leave the lines below commented for the dashboard-managed flow)
 # USE_CONFIG_FILE=1
 # TUNNEL_ID=00000000-0000-0000-0000-000000000000
-
-# --- Tailscale (optional, for SSH access to the host) ---
-#
-# The tailscale service in docker-compose.yml is opt-in via a compose profile,
-# so it does NOT start by default with `docker compose up -d`. Start it with:
-#   docker compose --profile tailscale up -d
-#
-# Auth uses an OAuth CLIENT (not an auth key). Auth keys expire after at most
-# 90 days and can't be extended, which would force a re-deploy every 90 days.
-# OAuth client secrets do NOT expire, so the container runs unattended forever.
-# The trade-off: OAuth-registered nodes must be tagged (Tailscale requirement),
-# so docker-compose.yml passes --advertise-tags=tag:server.
-#
-# Create the OAuth client at:
-#   https://login.tailscale.com/admin/settings/trust-credentials
-#   -> Credentials -> Generate credential -> OAuth
-#   -> grant BOTH "Devices - core" (devices:core) AND "Policy File"
-#      (policy_file) scopes (same client is reused by the GitOps ACL workflow)
-#   -> assign the tag:server tag
-#
-# The credentials are BAKED INTO the custom tailscale image at build time
-# (see docker/tailscale/Dockerfile and .github/workflows/build.yml). They are
-# NOT read from .env on the host. Store them as GitHub ORG secrets/variables:
-#   TS_OAUTH_ID      - ORG VARIABLE (vars.*). Client ID (non-secret, starts with k).
-#   TS_OAUTH_SECRET  - ORG SECRET (secrets.*). Client secret (starts with tskey-client-).
-# Both scoped to this repo only. The build workflow reads them and passes as
-# build-args to docker/tailscale/Dockerfile.
-#
-# SECURITY: the custom tailscale image is PRIVATE on GHCR (it contains the
-# OAuth client secret). Before `docker compose pull` works on a host, you need
-# a one-time `docker login ghcr.io` with a PAT that has `read:packages` scope.
-# Create the PAT at https://github.com/settings/tokens (classic).
-#
-# Requires host sshd listening on 0.0.0.0:22 (default on most Linux distros).
-# Verify with: ssh <user>@telemetry-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,10 @@ services:
     environment:
       PATH: "/home/ubuntu/telemetry_server/venv/bin:/usr/local/bin:/usr/bin:/bin"
       VIRTUAL_ENV: "/home/ubuntu/telemetry_server/venv"
+      # Comma-separated list of origins allowed to make cross-origin requests
+      # to the API. Leave blank (or unset) to use the built-in default list
+      # in src/autoboat_telemetry_server/__init__.py. See .env.example.
+      CORS_ORIGINS: ${CORS_ORIGINS:-}
     volumes:
       # Persist the SQLite databases (instances.db, hashes.db) across restarts.
       - prod-instance-data:/home/ubuntu/telemetry_server/src/instance
@@ -61,6 +65,7 @@ services:
     environment:
       PATH: "/home/ubuntu/telemetry_server/venv/bin:/usr/local/bin:/usr/bin:/bin"
       VIRTUAL_ENV: "/home/ubuntu/telemetry_server/venv"
+      CORS_ORIGINS: ${CORS_ORIGINS:-}
     volumes:
       - test-instance-data:/home/ubuntu/telemetry_server/src/instance
     expose:
@@ -140,7 +145,7 @@ services:
     #
     # Requires:
     #   - /dev/net/tun on the host (Linux: `modprobe tun` if missing)
-    #   - Host sshd listening on 0.0.0.0:22 (default on most distros)
+    #   - Host sshd listening on 0.0.0.0:22 (default on most Linux distros)
     #
     # The OAuth credentials are BAKED INTO the custom image (built in
     # .github/workflows/build.yml from docker/tailscale/Dockerfile). The

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ description = "Telemetry server for Autoboat"
 
 dependencies = [
     "Flask>=3.1,<4.0",
+    "Flask-Cors>=5.0,<7.0",
     "Flask-SQLAlchemy>=3.1,<4.0",
     "gunicorn>=23.0,<27.0",
     "blinker>=1.9,<2.0",

--- a/src/autoboat_telemetry_server/__init__.py
+++ b/src/autoboat_telemetry_server/__init__.py
@@ -2,9 +2,11 @@
 
 __all__ = ["HOME_DIR", "INSTANCE_DIR", "create_app", "shared_lock_manager"]
 
+import os
 from pathlib import Path
 
 from flask import Flask as _flask
+from flask_cors import CORS
 
 from .lock_manager import LockManager
 from .models import db
@@ -30,6 +32,26 @@ from autoboat_telemetry_server.routes import (  # noqa: E402
     WaypointEndpoint,
 )
 
+# Origins allowed to make cross-origin requests to this API.
+#
+# The Autoboat website (https://autoboat.aoe.vt.edu) fetches boat positions
+# from the telemetry API in the browser, so the server must send
+# Access-Control-Allow-Origin headers for that origin. Local development of
+# the website (vite dev server on localhost) is also allowed.
+DEFAULT_CORS_ORIGINS: list[str] = [
+    "https://autoboat.aoe.vt.edu",
+    "https://vt-autoboat-telemetry.uk",
+    "https://www.vt-autoboat-telemetry.uk",
+    "https://test.vt-autoboat-telemetry.uk",
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
+]
+
+
+def _parse_cors_origins(raw: str) -> list[str]:
+    """Split a comma-separated CORS_ORIGINS env var into a list of origins."""
+    return [origin.strip() for origin in raw.split(",") if origin.strip()]
+
 
 def create_app() -> _flask:
     """
@@ -45,6 +67,21 @@ def create_app() -> _flask:
 
     config_path = INSTANCE_DIR / "config.py"
     app.config.from_pyfile(config_path)
+
+    # Determine the allowed CORS origins. Precedence (highest first):
+    #   1. CORS_ORIGINS env var (comma-separated) — works on existing
+    #      deployments without rebuilding, since src/instance/config.py is
+    #      persisted in a named volume and not overwritten on image updates.
+    #   2. app.config["CORS_ORIGINS"] (set in src/instance/config.py) —
+    #      applies on fresh installs where config.py is seeded from the image.
+    #   3. DEFAULT_CORS_ORIGINS — the known website + telemetry origins.
+    env_origins = os.environ.get("CORS_ORIGINS")
+    if env_origins:
+        origins: str | list[str] = _parse_cors_origins(env_origins)
+    else:
+        origins = app.config.get("CORS_ORIGINS", DEFAULT_CORS_ORIGINS)
+
+    CORS(app, origins=origins)
 
     db.init_app(app)
 

--- a/src/instance/config.py
+++ b/src/instance/config.py
@@ -6,3 +6,19 @@ SQLALCHEMY_BINDS = {
     "hashes": f"sqlite:///{(BASE_DIR / 'hashes.db').as_posix()}",
 }
 SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+# Origins allowed to make cross-origin requests to this API.
+#
+# Used by create_app() when the CORS_ORIGINS env var is NOT set. To override
+# on an existing deployment without rebuilding the image, set the
+# CORS_ORIGINS env var (comma-separated) in docker-compose.yml instead of
+# editing this file — src/instance/config.py is persisted in a named volume
+# and is not overwritten on image updates.
+CORS_ORIGINS = [
+    "https://autoboat.aoe.vt.edu",
+    "https://vt-autoboat-telemetry.uk",
+    "https://www.vt-autoboat-telemetry.uk",
+    "https://test.vt-autoboat-telemetry.uk",
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
+]


### PR DESCRIPTION
## Summary

Enables cross-origin requests to the telemetry API so the Autoboat website frontend can fetch boat positions directly from the browser.

The website at **https://autoboat.aoe.vt.edu** now has a `/live` page that polls `GET /instance_manager/get_all_instance_info` and `GET /boat_status/get/<id>` every few seconds and renders boat positions on a Leaflet map. Browsers block these requests unless the API responds with `Access-Control-Allow-Origin` headers for the website's origin. This PR adds that.

## Changes

- **`pyproject.toml`** — add `Flask-Cors>=5.0,<7.0` to dependencies.
- **`src/autoboat_telemetry_server/__init__.py`** — in `create_app()`, call `CORS(app, origins=...)` after loading config and before `db.init_app(app)`. Origins are resolved with this precedence:
  1. `CORS_ORIGINS` env var (comma-separated) — highest priority, works on **existing** deployments without rebuilding (see deployment note below).
  2. `app.config["CORS_ORIGINS"]` — set in `src/instance/config.py`, applies on fresh installs.
  3. `DEFAULT_CORS_ORIGINS` — built-in list: the website origin, the prod/test telemetry origins, and `localhost:5173` for local dev.
- **`src/instance/config.py`** — add a `CORS_ORIGINS` list mirroring the built-in default, so fresh installs work out of the box even without the env var.
- **`.env.example`** — document the `CORS_ORIGINS` env var.
- **`docker-compose.yml`** — forward `CORS_ORIGINS` (from `.env`) into the `telemetry-prod` and `telemetry-test` containers' `environment:`.

## Default allowed origins

```python
DEFAULT_CORS_ORIGINS = [
    "https://autoboat.aoe.vt.edu",          # website (prod)
    "https://vt-autoboat-telemetry.uk",      # telemetry (prod, same-origin dashboard)
    "https://www.vt-autoboat-telemetry.uk",  # telemetry (prod www)
    "https://test.vt-autoboat-telemetry.uk", # telemetry (staging)
    "http://localhost:5173",                 # website local dev (vite)
    "http://127.0.0.1:5173",                 # website local dev (vite, alt)
]
```

## Deployment note (important)

`src/instance/config.py` is persisted in a named Docker volume (`prod-instance-data` / `test-instance-data`) and is **not** overwritten on image updates (only seeded on first start). This means:

- Changes to `src/instance/config.py` in this PR only take effect on **fresh installs** (new volume).
- For **existing** prod/test deployments to pick up CORS, either:
  - **(recommended)** set `CORS_ORIGINS` in `.env` on the host and `docker compose up -d` — the env var is read directly in `create_app()`, bypassing the persisted `config.py`. No volume surgery, no rebuild.
  - **(alternative)** `docker exec` into the container and edit `config.py` inside the volume to add `CORS_ORIGINS = [...]`.

If `CORS_ORIGINS` is unset/blank **and** the persisted `config.py` predates this PR (so it has no `CORS_ORIGINS`), `create_app()` falls back to `DEFAULT_CORS_ORIGINS` — so CORS works out of the box on existing deployments too, just with the hardcoded default list.

## Testing

- `flask-cors` is a well-established package; `CORS(app, origins=[...])` is the standard initialization.
- The app still boots: `CORS()` is called after `app.config.from_pyfile(...)` and before `db.init_app(app)`, so it doesn't interfere with DB setup.
- Non-browser clients (the cron job hitting `/instance_manager/clean_instances`, the boat clients POSTing telemetry) are unaffected — CORS only adds response headers; it doesn't reject requests.

## Related

- Website PR (companion): adds the `/live` Live Map page that consumes this API. `autoboat-vt/website`.
